### PR TITLE
Removing template breaking trailing commas

### DIFF
--- a/lamp-stack-1478287817_1530269327 (3).json
+++ b/lamp-stack-1478287817_1530269327 (3).json
@@ -162,7 +162,7 @@
                   "[main]\n",
                   "stack=", { "Ref" : "AWS::StackId" }, "\n",
                   "region=", { "Ref" : "AWS::Region" }, "\n",
-                  "interval=6", "\n",
+                  "interval=6", "\n"
                 ]]},
                 "mode"    : "000400",
                 "owner"   : "root",
@@ -237,7 +237,7 @@
              "         --stack ", { "Ref" : "AWS::StackName" },
              "         --resource WebServerInstance ",
              "         --region ", { "Ref" : "AWS::Region" }, "\n"
-        ]]}},        
+        ]]}}
       },
       "CreationPolicy" : {
         "ResourceSignal" : {


### PR DESCRIPTION
As is, the template is not valid because of trailing commas at the end of two lines